### PR TITLE
Use exact " diffusers " 0.25.1 to enable position net

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a
-diffusers>=0.25.1
+diffusers==0.25.1
 einops
 gradio
 gradio_client


### PR DESCRIPTION
People who already have `diffusers 0.26.x` installed are missing the " position net " embedding. That's actually been commented out of the current `diffusers` code. However we should ensure that `0.25.1` is installed for everyone , including users who have a newer version thanks ..

—   Diffusers " position net " :
[ [https://github.com/search?q=repo%3Ahuggingface%2Fdiffusers%20positionnet&type=code](https://github.com/search?q=repo%3Ahuggingface%2Fdiffusers%20positionnet&type=code) ]